### PR TITLE
Remove the assumption that the field is still a text field.

### DIFF
--- a/system/expressionengine/third_party/freeform_grid/views/base.js
+++ b/system/expressionengine/third_party/freeform_grid/views/base.js
@@ -22,7 +22,7 @@
 
         update: function() {
             var my = this;
-            this.fields   = this.el.find('input[type="text"]');
+            this.fields   = this.el.find('input');
             this.headings = [];
             $(this.fields).each(function(i,field) {
                 my.headings.push({heading: $(field).val()});
@@ -55,7 +55,7 @@
             this.rows       = [];
             table_rows.each(function(i, row) {
                 var data = [],
-                    cells = $(row).find('input[type="text"]');
+                    cells = $(row).find('input');
                 cells.each(function(i, cell) {
                     data.push($(cell).val());
                 });


### PR DESCRIPTION
The Javascript assums that the field is still a text field. This prevents another Javascript from changing the field to "url" or "email" or "tel" or even "hidden".
